### PR TITLE
Update color scheme to lime green and enhance chart visibility

### DIFF
--- a/Admin_pannel/client/global.css
+++ b/Admin_pannel/client/global.css
@@ -13,51 +13,51 @@
   */
   :root {
     /* Pastel blue / white theme (H S% L% format) */
-    --background: 210 60% 98%; /* very light pastel blue */
+    --background: 0 0% 100%; /* white background */
     --foreground: 215 18% 18%; /* deep blue for text */
 
-    --card: 210 60% 100%; /* near-white card base */
+    --card: 0 0% 100%; /* white card base */
     --card-foreground: 215 18% 18%;
 
-    --popover: 210 60% 100%;
+    --popover: 0 0% 100%;
     --popover-foreground: 215 18% 18%;
 
-    --primary: 205 70% 85%; /* pastel blue */
+    --primary: 78 100% 84%; /* lime (#E7FFAD) */
     --primary-foreground: 215 22% 18%;
 
-    --secondary: 210 40% 96%;
+    --secondary: 78 100% 96%;
     --secondary-foreground: 215 18% 18%;
 
-    --muted: 210 40% 96%;
+    --muted: 78 100% 96%;
     --muted-foreground: 215 14% 45%;
 
-    --accent: 205 80% 88%;
+    --accent: 78 100% 88%;
     --accent-foreground: 215 18% 18%;
 
     --destructive: 0 84% 60%;
     --destructive-foreground: 210 40% 98%;
 
-    --border: 210 60% 92%;
-    --input: 210 60% 95%;
-    --ring: 205 70% 85%;
+    --border: 78 40% 90%;
+    --input: 78 100% 97%;
+    --ring: 78 100% 84%;
 
     --radius: 0.75rem;
 
-    --sidebar-background: 210 55% 98%;
+    --sidebar-background: 0 0% 100%;
 
     --sidebar-foreground: 215 18% 18%;
 
-    --sidebar-primary: 205 75% 85%;
+    --sidebar-primary: 78 100% 84%;
 
     --sidebar-primary-foreground: 215 18% 18%;
 
-    --sidebar-accent: 210 60% 96%;
+    --sidebar-accent: 78 100% 96%;
 
     --sidebar-accent-foreground: 215 18% 18%;
 
-    --sidebar-border: 210 60% 92%;
+    --sidebar-border: 78 40% 90%;
 
-    --sidebar-ring: 205 70% 85%;
+    --sidebar-ring: 78 100% 84%;
 
     /* Additional variables for loader component */
     --radius-sm: calc(var(--radius) - 4px);
@@ -126,7 +126,7 @@
 @layer utilities {
   /* Glass surface utility for dialogs and panels */
   .glass {
-    background: rgba(240, 248, 255, 0.66); /* light pastel blue */
+    background: rgba(231, 255, 173, 0.66); /* light lime */
     backdrop-filter: blur(8px) saturate(120%);
     -webkit-backdrop-filter: blur(8px) saturate(120%);
     border: 1px solid rgba(255, 255, 255, 0.6);

--- a/Admin_pannel/client/pages/Analytics.tsx
+++ b/Admin_pannel/client/pages/Analytics.tsx
@@ -50,8 +50,8 @@ export default function Analytics() {
               <CartesianGrid vertical={false} strokeDasharray="3 3" />
               <XAxis dataKey="month" tickLine={false} axisLine={false} />
               <YAxis />
-              <Line type="monotone" dataKey="reported" stroke="var(--color-reported)" strokeWidth={2} dot={false} />
-              <Line type="monotone" dataKey="resolved" stroke="var(--color-resolved)" strokeWidth={2} dot={false} />
+              <Line type="monotone" dataKey="reported" stroke="var(--color-reported)" strokeWidth={3} dot={false} />
+              <Line type="monotone" dataKey="resolved" stroke="var(--color-resolved)" strokeWidth={3} dot={false} />
               <ChartTooltip content={<ChartTooltipContent />} />
               <ChartLegend content={<ChartLegendContent />} />
             </LineChart>

--- a/Admin_pannel/client/pages/Index.tsx
+++ b/Admin_pannel/client/pages/Index.tsx
@@ -57,7 +57,7 @@ export default function Index() {
                 <CartesianGrid vertical={false} strokeDasharray="3 3" />
                 <XAxis dataKey="date" tickLine={false} axisLine={false} minTickGap={24} tickMargin={8} />
                 <YAxis hide />
-                <Area type="monotone" dataKey="value" stroke="var(--color-Reports)" fill="var(--color-Reports)" fillOpacity={0.15} />
+                <Area type="monotone" dataKey="value" stroke="var(--color-Reports)" strokeWidth={2} fill="var(--color-Reports)" fillOpacity={0.25} />
                 <ChartTooltip content={<ChartTooltipContent nameKey="Reports" />} />
               </AreaChart>
             </ChartContainer>

--- a/Admin_pannel/client/pages/supervisor/Analytics.tsx
+++ b/Admin_pannel/client/pages/supervisor/Analytics.tsx
@@ -64,7 +64,7 @@ export default function SupervisorAnalytics() {
               <CartesianGrid vertical={false} strokeDasharray="3 3" />
               <XAxis dataKey="name" tickLine={false} axisLine={false} tickMargin={8} />
               <YAxis hide />
-              <Line type="monotone" dataKey="value" stroke="var(--color-value)" strokeWidth={2} dot={false} />
+              <Line type="monotone" dataKey="value" stroke="var(--color-value)" strokeWidth={3} dot={false} />
               <ChartTooltip content={<ChartTooltipContent />} />
               <ChartLegend content={<ChartLegendContent />} />
             </LineChart>

--- a/Admin_pannel/client/pages/supervisor/Dashboard.tsx
+++ b/Admin_pannel/client/pages/supervisor/Dashboard.tsx
@@ -66,7 +66,7 @@ export default function SupervisorDashboard() {
                 <CartesianGrid vertical={false} strokeDasharray="3 3" />
                 <XAxis dataKey="date" tickLine={false} axisLine={false} minTickGap={24} tickMargin={8} />
                 <YAxis hide />
-                <Area type="monotone" dataKey="value" stroke="var(--color-Reports)" fill="var(--color-Reports)" fillOpacity={0.15} />
+                <Area type="monotone" dataKey="value" stroke="var(--color-Reports)" strokeWidth={2} fill="var(--color-Reports)" fillOpacity={0.25} />
                 <ChartTooltip content={<ChartTooltipContent nameKey="Reports" />} />
               </AreaChart>
             </ChartContainer>


### PR DESCRIPTION
## Purpose
Update the application's color scheme from pastel blue to lime green (#E7FFAD) and white as requested by the user. Additionally, enhance chart visibility by making graph lines darker and more prominent across all analytics sections.

## Code changes
- **Global CSS**: Updated CSS variables to use lime green (#E7FFAD) as primary color and white backgrounds, replacing the previous pastel blue theme
- **Chart styling**: Increased stroke width from 2px to 3px for line charts in Analytics pages to make graphs more visible
- **Area charts**: Enhanced stroke width to 2px and increased fill opacity from 0.15 to 0.25 for better visibility
- **Glass effect**: Updated glass utility background color to match the new lime green themeTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/58da68c051704ee3977ed1d26ee75676/pixel-world)

👀 [Preview Link](https://58da68c051704ee3977ed1d26ee75676-pixel-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>58da68c051704ee3977ed1d26ee75676</projectId>-->
<!--<branchName>pixel-world</branchName>-->